### PR TITLE
Fix the issue key pattern (when "_" is included in the issue key)

### DIFF
--- a/src/main/java/hudson/plugins/backlog/BacklogChangelogAnnotator.java
+++ b/src/main/java/hudson/plugins/backlog/BacklogChangelogAnnotator.java
@@ -27,7 +27,7 @@ public class BacklogChangelogAnnotator extends ChangeLogAnnotator {
 			.getLog(BacklogChangelogAnnotator.class);
 
 	public static final Pattern ISSUE_KEY_PATTERN = Pattern
-			.compile("(?:(?<![/A-Z0-9a-z-])([A-Z0-9]+-[1-9][0-9]*)|\\[\\[([A-Z0-9]+-[1-9][0-9]*)\\]\\])");
+			.compile("(?:(?<![/A-Z0-9a-z-_])([A-Z0-9_]+-[1-9][0-9]*)|\\[\\[([A-Z0-9_]+-[1-9][0-9]*)\\]\\])");
 
 	@Override
 	public void annotate(AbstractBuild<?, ?> build, Entry change,

--- a/src/test/java/hudson/plugins/backlog/BacklogChangelogAnnotatorTest.java
+++ b/src/test/java/hudson/plugins/backlog/BacklogChangelogAnnotatorTest.java
@@ -20,37 +20,35 @@ public class BacklogChangelogAnnotatorTest {
 	@Test
 	public final void testAnnotate() {
 		{
-			String src = "[[BLG-123]]について、対応しました。";
+			String src = "[[BLG_2-123]]について、対応しました。";
 			MarkupText text = new MarkupText(src);
 			annotator.annotate("https://backlog.backlog.jp/", text);
 			Assert.assertEquals(
-					"<a href=\"https://backlog.backlog.jp/view/BLG-123\">[[BLG-123]]</a>について、対応しました。",
-					text.toString(false));
-		}
-
-		{
-			String src = "BLG-123について、対応しました。";
-			MarkupText text = new MarkupText(src);
-			annotator.annotate("https://backlog.backlog.jp/", text);
-			Assert.assertEquals(
-					"<a href=\"https://backlog.backlog.jp/view/BLG-123\">BLG-123</a>について、対応しました。",
-					text.toString(false));
-		}
-
-		{
-			String src = "IEの場合に表示がおかしかったのを修正（BLG-1384）";
-			MarkupText text = new MarkupText(src);
-			annotator.annotate("https://backlog.backlog.jp/", text);
-			Assert.assertEquals(
-					"IEの場合に表示がおかしかったのを修正（<a href=\"https://backlog.backlog.jp/view/BLG-1384\">BLG-1384</a>）",
+					"<a href=\"https://backlog.backlog.jp/view/BLG_2-123\">[[BLG_2-123]]</a>について、対応しました。",
 					text.toString(false));
 		}
 		{
-			String src = "2009-05-15 IEの場合に表示がおかしかったのを修正（BLG-1384）";
+			String src = "BLG_2-123について、対応しました。";
 			MarkupText text = new MarkupText(src);
 			annotator.annotate("https://backlog.backlog.jp/", text);
 			Assert.assertEquals(
-					"2009-05-15 IEの場合に表示がおかしかったのを修正（<a href=\"https://backlog.backlog.jp/view/BLG-1384\">BLG-1384</a>）",
+					"<a href=\"https://backlog.backlog.jp/view/BLG_2-123\">BLG_2-123</a>について、対応しました。",
+					text.toString(false));
+		}
+		{
+			String src = "IEの場合に表示がおかしかったのを修正（BLG_2-1384）";
+			MarkupText text = new MarkupText(src);
+			annotator.annotate("https://backlog.backlog.jp/", text);
+			Assert.assertEquals(
+					"IEの場合に表示がおかしかったのを修正（<a href=\"https://backlog.backlog.jp/view/BLG_2-1384\">BLG_2-1384</a>）",
+					text.toString(false));
+		}
+		{
+			String src = "2009-05-15 IEの場合に表示がおかしかったのを修正（BLG_2-1384）";
+			MarkupText text = new MarkupText(src);
+			annotator.annotate("https://backlog.backlog.jp/", text);
+			Assert.assertEquals(
+					"2009-05-15 IEの場合に表示がおかしかったのを修正（<a href=\"https://backlog.backlog.jp/view/BLG_2-1384\">BLG_2-1384</a>）",
 					text.toString(false));
 		}
 	}
@@ -58,7 +56,7 @@ public class BacklogChangelogAnnotatorTest {
 	@Test
 	public final void testIssuePattern() {
 		{
-			String src = "[[BLG-123]]について、対応しました。";
+			String src = "[[BLG_2-123]]について、対応しました。";
 			Matcher m = BacklogChangelogAnnotator.ISSUE_KEY_PATTERN
 					.matcher(src);
 			while (m.find()) {
@@ -70,7 +68,7 @@ public class BacklogChangelogAnnotatorTest {
 			}
 		}
 		{
-			String src = "BLG-123について、対応しました。";
+			String src = "BLG_2-123について、対応しました。";
 			Matcher m = BacklogChangelogAnnotator.ISSUE_KEY_PATTERN
 					.matcher(src);
 			while (m.find()) {


### PR DESCRIPTION
課題キーには、アンダースコアが含まれる可能性がありますが、現在のパターンでは考慮されていません。

現在、課題キーは `{プロジェクトキー}-{番号}` という形式を取っています。
プロジェクトキーには、半角英大文字と半角数字の他に、アンダースコアを使用できるため、課題キーにもアンダースコアが含まれる可能性があります。
