### PR TITLE
[JENKINS-69092] Migrate Backlog to Jakarta Mail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.25</version>
+    <version>4.42</version>
+    <relativePath />
   </parent>
 
   <properties>
-    <jenkins.version>2.46.1</jenkins.version>
-    <findbugs.failOnError>false</findbugs.failOnError>
+    <jenkins.version>2.332.1</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <spotbugs.threshold>High</spotbugs.threshold> <!-- TODO fix violations -->
   </properties>
 
   <artifactId>backlog</artifactId>
@@ -17,7 +20,7 @@
   <version>2.7-SNAPSHOT</version>
   <name>Jenkins Backlog plugin</name>
   <description>Integrates Jenkins to Backlog</description>
-  <url>https://github.com/jenkinsci/backlog-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <developers>
     <developer>
       <id>dragon3</id>
@@ -29,105 +32,116 @@
     </developer>
   </developers>
   <scm>
-  	<connection>scm:git:git://github.com/jenkinsci/backlog-plugin.git</connection>
-  	<developerConnection>scm:git:git@github.com:jenkinsci/backlog-plugin.git</developerConnection>
-  	<url>http://github.com/jenkinsci/backlog-plugin</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
     <tag>HEAD</tag>
   </scm>
-  <build>
-  	<plugins>
-  		<plugin>
-  			<groupId>org.apache.maven.plugins</groupId>
-  			<artifactId>maven-compiler-plugin</artifactId>
-  			<version>2.3.2</version>
-  			<configuration>
-  			   <encoding>UTF-8</encoding>
-  			</configuration>
-  		</plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.1</version>
-      </plugin>
-  	</plugins>
-  </build>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1500.ve4d05cd32975</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
-    <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.1</version>
-        <scope>test</scope>
-    </dependency>
     <dependency>
     	<groupId>org.jenkins-ci.plugins</groupId>
     	<artifactId>subversion</artifactId>
-    	<version>2.7.2</version>
         <optional>true</optional>
     </dependency>
     <dependency>
-    	<groupId>com.github.lookfirst</groupId>
-    	<artifactId>sardine</artifactId>
-    	<version>5.7</version>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>apache-httpcomponents-client-4-api</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.github.lookfirst</groupId>
+        <artifactId>sardine</artifactId>
+        <version>5.7</version>
+        <exclusions>
+            <!-- Provided by apache-httpcomponents-client-4-api plugin -->
+            <exclusion>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+            </exclusion>
+          </exclusions>
     </dependency>
     <dependency>
     	<groupId>org.jenkins-ci.plugins</groupId>
     	<artifactId>git</artifactId>
-    	<version>3.0.4</version>
     	<optional>true</optional>
+    </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>jackson2-api</artifactId>
     </dependency>
     <dependency>
         <groupId>com.nulab-inc</groupId>
         <artifactId>backlog4j</artifactId>
         <version>2.1.4</version>
+        <exclusions>
+            <!-- Provided by jackson2-api plugin -->
+            <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>mailer</artifactId>
-        <version>1.18</version>
     </dependency>
     <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.7</version>
     </dependency>
     <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-multibranch</artifactId>
-        <version>2.12</version>
     </dependency>
     <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>
-        <version>2.1.12</version>
     </dependency>
     <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>structs</artifactId>
-        <version>1.5</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-credentials</artifactId>
-        <version>1.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-scm-step</artifactId>
-        <version>2.4</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-support</artifactId>
-        <version>2.6</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>junit</artifactId>
-        <version>1.6</version>
         <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/hudson/plugins/backlog/BacklogNotifier.java
+++ b/src/main/java/hudson/plugins/backlog/BacklogNotifier.java
@@ -16,8 +16,8 @@ import hudson.tasks.*;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;


### PR DESCRIPTION
See [JENKINS-69092](https://issues.jenkins.io/browse/JENKINS-69092). As of [Mailer 435.v79ef3972b_5c7](https://github.com/jenkinsci/mailer-plugin/releases/tag/435.v79ef3972b_5c7) and [Email Extension 2.90](https://github.com/jenkinsci/email-ext-plugin/releases/tag/email-ext-2.90), the package namespace has changed from `javax.mail` to `jakarta.mail`. This PR adapts this plugin to the migration.

CC @ikikko